### PR TITLE
Verificar erros na função atualizar_resumo_pets

### DIFF
--- a/paginas/funcoes.py
+++ b/paginas/funcoes.py
@@ -640,8 +640,20 @@ def atualizar_resumo_pets(pets):
         pets - lista de dicionários com informações de pets de usuário
     """
     
+    if not hasattr(st.user, 'email'):
+        return
+
+    # Se não houver pets, salva mensagem e retorna
     if not pets:
         texto_final = "O usuário ainda não tem pets cadastrados."
+        # Conectando à base de dados e guardando a informação
+        db = firestore.client()
+        perfil_ref = db.collection(COLECAO_USUARIOS).document(st.user.email)
+        try:
+            perfil_ref.update({"resumos_pet": texto_final})
+        except Exception as e:
+            print(f"Erro ao salvar o resumo no perfil: {e}")
+        return
 
     resumos = []
     for info in pets:
@@ -662,11 +674,10 @@ def atualizar_resumo_pets(pets):
 
     # Conectando à base de dados e guardando a informação
     db = firestore.client()
-    pets_ref = db.collection(COLECAO_USUARIOS).document(st.user.email)
+    perfil_ref = db.collection(COLECAO_USUARIOS).document(st.user.email)
 
     try:
-      pets_ref.update({"resumos_pet": texto_final})
-
+        perfil_ref.update({"resumos_pet": texto_final})
     except Exception as e:
         print(f"Erro ao salvar o resumo no perfil: {e}")
         return None

--- a/paginas/pets.py
+++ b/paginas/pets.py
@@ -1,4 +1,5 @@
 import streamlit as st
+from datetime import date
 from paginas.funcoes import (
     salvar_pet, 
     obter_pets,
@@ -116,7 +117,7 @@ def editar_pet_dialog():
                         st.success(f"🎉 Pet **{nome_pet}** atualizado com sucesso!")
                         registrar_acao_usuario("Editar Pet", f"Usuário editou o pet {nome_pet}")
                         st.session_state.pet_editando = None
-
+                        atualizar_resumo_pets(obter_pets())
                         st.rerun()
                     else:
                         st.error("Erro ao atualizar o pet. Tente novamente!")
@@ -130,8 +131,6 @@ pets = obter_pets()
 # Mostrar diálogo se há pet sendo editado
 if st.session_state.pet_editando:
     editar_pet_dialog()
-    # Atualizando o resumo de informações dos pets para ser utilizado pelo chatbot
-    atualizar_resumo_pets(pets)
 
 if pets:
     st.subheader("🏠 Meus Pets")
@@ -177,7 +176,7 @@ if pets:
                                     if excluir_pet(pet['id']):
                                         st.success(f"Pet {pet['nome']} excluído com sucesso!")
                                         registrar_acao_usuario("Excluir Pet", f"Usuário excluiu o pet {pet['nome']}")
-                                        atualizar_resumo_pets(pets)
+                                        atualizar_resumo_pets(obter_pets())
                                         st.rerun()
                                     else:
                                         st.error("Erro ao excluir pet!")
@@ -267,8 +266,6 @@ with st.form("cadastro_pet", clear_on_submit=True):
                     alimentacao=alimentacao_pet,
                     url_foto=None  # Inicialmente sem foto
                 )
-                # Atualizando o resumo de informações dos pets para ser utilizado pelo chatbot
-                atualizar_resumo_pets(pets)
                 
                 # Se o pet foi salvo e há uma foto, faz o upload
                 if pet_id and foto_pet is not None:
@@ -303,6 +300,7 @@ with st.form("cadastro_pet", clear_on_submit=True):
                     st.success(f"🎉 Pet **{nome_pet}** cadastrado com sucesso!")
                     st.balloons()
                     registrar_acao_usuario("Cadastrar Pet", f"Usuário cadastrou o pet {nome_pet} ({especie_pet}, {sexo_pet}, {raca_pet})")
+                    atualizar_resumo_pets(obter_pets())
                     st.rerun()
                 else:
                     st.error("Erro ao cadastrar o pet. Tente novamente!")


### PR DESCRIPTION
Fix `atualizar_resumo_pets` logic and update its call sites to ensure the pet summary is always accurate.

Previously, `atualizar_resumo_pets` would incorrectly save an empty string when a user had no pets. Its calls in `pets.py` were also out of sync, using an outdated list of pets after modifications (edit, delete, add), leading to an incorrect summary being displayed. This PR ensures the summary reflects the current state of pets and correctly handles the "no pets" scenario. It also adds a missing `datetime` import.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5b3d0ec-61ab-4a50-8f53-dece575d39d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e5b3d0ec-61ab-4a50-8f53-dece575d39d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

